### PR TITLE
FEATURE - NFT Creator | Leaderboard | Artist page

### DIFF
--- a/config/leaderboardSlice.ts
+++ b/config/leaderboardSlice.ts
@@ -1,0 +1,50 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import axios from "axios";
+import { LeaderboardType } from "../types/LeaderboardType";
+
+export type LeaderboardProps = {
+  data: LeaderboardType[];
+  isLoading: boolean;
+  hasError: boolean;
+};
+
+const initialState: LeaderboardProps = {
+  data: [],
+  hasError: false,
+  isLoading: false,
+};
+
+export const getLeaderboard = createAsyncThunk("marketplace/GET_LEADERBOARD", async () => {
+  const response = await axios.get("https://api.cryptoslam.io/v1/collections/top-100?timeRange=all");
+  return response.data;
+});
+
+const leaderboardSlice = createSlice({
+  name: "leaderboard",
+  initialState,
+  reducers: {
+    clearStore(state: LeaderboardProps) {
+      state.data = [];
+      state.hasError = false;
+      state.isLoading = false;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(getLeaderboard.fulfilled, (state, action) => {
+      state.data = action.payload;
+      state.isLoading = false;
+      state.hasError = false;
+    });
+    builder.addCase(getLeaderboard.pending, (state) => {
+      state.isLoading = true;
+    });
+    builder.addCase(getLeaderboard.rejected, (state) => {
+      state.isLoading = false;
+      state.hasError = true;
+    });
+  },
+});
+
+export const { clearStore } = leaderboardSlice.actions;
+
+export default leaderboardSlice.reducer;

--- a/config/store.ts
+++ b/config/store.ts
@@ -6,10 +6,12 @@ import marketplaceReducer from "./marketplaceSlice";
 import portfolioReducer from "./portfolioSlice";
 import landingReducer from "./landingSlice";
 import tokenReducer from "./tokenSlice";
+import leaderboardReducer from "./leaderboardSlice";
 
 export const rootReducer = combineReducers({
   marketplace: marketplaceReducer,
   token: tokenReducer,
+  leaderboard: leaderboardReducer,
   landing: persistReducer({ key: "landing", storage }, landingReducer),
   portfolio: persistReducer({ key: "portfolio", storage }, portfolioReducer),
 });

--- a/config/tokenSlice.ts
+++ b/config/tokenSlice.ts
@@ -13,6 +13,7 @@ export type TokenProps = {
   };
   isLoading: boolean;
   hasError: boolean;
+  owners: TokenType[];
 };
 
 type GetTokenProps = {
@@ -25,6 +26,15 @@ type GetTokenProps = {
     getAllTokenIds: Function;
   };
   getWishlist: Function;
+};
+
+type GetOwnerProps = {
+  address: string;
+  token_id: string;
+  chain: string;
+  token: {
+    getTokenIdOwners: Function;
+  };
 };
 
 type GetCollectionProps = {
@@ -76,6 +86,7 @@ const initialState: TokenProps = {
   },
   hasError: false,
   isLoading: false,
+  owners: [],
 };
 
 export const getTokenData = createAsyncThunk("token/GET_TOKEN", async (data: GetTokenProps) => {
@@ -102,6 +113,15 @@ export const getCollection = createAsyncThunk("token/GET_COLLECTION", async (dat
     metadata: JSON.parse(token.metadata),
   }));
   return collection;
+});
+
+export const getOwners = createAsyncThunk("token/GET_OWNERS", async (data: GetOwnerProps) => {
+  const { result } = await data.token.getTokenIdOwners({
+    chain: data.chain,
+    address: data.address,
+    token_id: data.token_id,
+  });
+  return result;
 });
 
 export const saveTokenInWishlist = createAsyncThunk(
@@ -180,6 +200,13 @@ const tokenSlice = createSlice({
     });
     builder.addCase(removeTokenFromWishlist.rejected, (state) => {
       state.isLoading = false;
+      state.hasError = true;
+    });
+    builder.addCase(getOwners.fulfilled, (state, action) => {
+      state.owners = action.payload;
+      state.hasError = false;
+    });
+    builder.addCase(getOwners.rejected, (state) => {
       state.hasError = true;
     });
   },

--- a/pages/artist/[address].tsx
+++ b/pages/artist/[address].tsx
@@ -1,0 +1,45 @@
+import type { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { useMoralis } from "react-moralis";
+import { useSelector, useDispatch } from "react-redux";
+import ErrorBanner from "../../components/ErrorBanner/ErrorBanner";
+import { AppDispatch } from "../../config/store";
+import StoreType from "../../types/StoreType";
+import { Wrapper, Main, Title, LoadingWrapper } from "../../styles/ArtistStyled";
+
+const Artist: NextPage = () => {
+  const { isInitialized, Moralis } = useMoralis();
+  const { query } = useRouter();
+  const dispatch = useDispatch<AppDispatch>();
+  const address: string = Array.isArray(query.address) ? query.address[0] : query.address || "";
+  const { data, isLoading, hasError, collection, owners } = useSelector((store: StoreType) => store.token);
+
+  useEffect(() => {
+    if (isInitialized) {
+      // Moralis.Web3API.account.getNFTs({ address: creatorAddress })
+    }
+  }, [isInitialized]);
+
+  const renderLoaderOrError = () => (
+    <Main>
+      <Wrapper>
+        {hasError && <ErrorBanner hasError={hasError} />}
+        {isLoading && <LoadingWrapper>Loading...</LoadingWrapper>}
+      </Wrapper>
+    </Main>
+  );
+
+  return isLoading || hasError ? (
+    renderLoaderOrError()
+  ) : (
+    <Main>
+      <Wrapper>
+        <Title>Artist</Title>
+        <span>{address}</span>
+      </Wrapper>
+    </Main>
+  );
+};
+
+export default Artist;

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -1,27 +1,41 @@
 import type { NextPage } from "next";
-import { Section, Main, Title, CollectionImage } from "../styles/LeaderboardStyled";
+import { Section, Main, Title, CollectionImage, LoadingWrapper } from "../styles/LeaderboardStyled";
 import { Table, Thead, Tbody, Tr, Th, Td } from "react-super-responsive-table";
 import "react-super-responsive-table/dist/SuperResponsiveTableStyle.css";
 import COLORS from "../constants/colors";
-import { useEffect, useState } from "react";
-import axios from "axios";
-import { LeaderboardType } from "../types/LeaderboardType";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { AppDispatch } from "../config/store";
+import StoreType from "../types/StoreType";
+import { useSelector } from "react-redux";
+import { getLeaderboard } from "../config/leaderboardSlice";
+import ErrorBanner from "../components/ErrorBanner/ErrorBanner";
+import { Loading } from "web3uikit";
 
 const Leaderboard: NextPage = () => {
-  const [leaderboardData, setLeaderboardData] = useState<LeaderboardType[]>([]);
+  const dispatch = useDispatch<AppDispatch>();
+  const { data, isLoading, hasError } = useSelector((store: StoreType) => store.leaderboard);
 
   useEffect(() => {
-    axios
-      .get("https://api.cryptoslam.io/v1/collections/top-100?timeRange=all")
-      .then(({ data }: { data: LeaderboardType[] }) => {
-        setLeaderboardData(data);
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-  }, []);
+    dispatch(getLeaderboard());
+  }, [dispatch]);
 
-  return (
+  const renderLoaderOrError = () => (
+    <Main>
+      <Section>
+        {hasError && <ErrorBanner hasError={hasError} />}
+        {isLoading && (
+          <LoadingWrapper>
+            <Loading spinnerColor={COLORS.PURPLE.DARK} />
+          </LoadingWrapper>
+        )}
+      </Section>
+    </Main>
+  );
+
+  return isLoading || hasError ? (
+    renderLoaderOrError()
+  ) : (
     <Main>
       <Section>
         <Title>Leaderboard</Title>
@@ -40,7 +54,7 @@ const Leaderboard: NextPage = () => {
             </Tr>
           </Thead>
           <Tbody>
-            {leaderboardData.map((item, i) => (
+            {data.map((item, i) => (
               <Tr key={i}>
                 <Td>
                   <CollectionImage src={item.iconUrl} />

--- a/styles/ArtistStyled.ts
+++ b/styles/ArtistStyled.ts
@@ -14,29 +14,28 @@ export const Main = styled.main`
   }
 `;
 
-export const Section = styled.section`
-  max-width: ${SCREEN.DESKTOP};
+export const Wrapper = styled.div`
+  max-width: ${SCREEN.TABLET_BIG};
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding: 0 20px;
+  padding: 50px 20px 0 20px;
+
+  @media only screen and (max-width: ${SCREEN.TABLET_SMALL}) {
+    padding-top: 20px;
+  }
 `;
 
-export const Title = styled.h2`
+export const Title = styled.h1`
   font-size: ${TYPOGRAPHY.SIZE.HEADLINE_1};
   font-weight: ${TYPOGRAPHY.WEIGHT.HEADLINE_1};
-  align-self: center;
-  margin: 45px 0;
-`;
-
-export const CollectionImage = styled.img`
-  width: 50px;
-  height: 50px;
+  margin: 0;
 `;
 
 export const LoadingWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
-  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 250px);
 `;

--- a/styles/TokenStyled.ts
+++ b/styles/TokenStyled.ts
@@ -43,11 +43,8 @@ export const LoadingWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
-
-  @media only screen and (max-width: ${SCREEN.TABLET_SMALL}) {
-    flex-direction: column;
-    align-items: center;
-  }
+  align-items: center;
+  min-height: calc(100vh - 250px);
 `;
 
 export const SkeletonColumn = styled.div`
@@ -98,7 +95,7 @@ export const TokenImage = styled.div`
   background-repeat: no-repeat;
   background-size: cover;
   width: 300px;
-  height: 425px;
+  height: 380px;
   border-radius: 10px;
   margin-bottom: 15px;
   border: 1px solid ${({ theme }: { theme: ThemeType }) => theme.BORDER};
@@ -187,9 +184,10 @@ export const InfoContainer = styled.section`
   margin: 20px 0;
 `;
 
-export const OwnedBy = styled.span`
+export const OwnedBy = styled.a`
   color: ${({ theme }: { theme: ThemeType }) => theme.TITLE};
   font-weight: ${TYPOGRAPHY.WEIGHT.SUBTITLE_1};
+  cursor: pointer;
 `;
 
 export const Table = styled.table`
@@ -205,4 +203,13 @@ export const TokenHeader = styled.div`
   width: max-content;
   padding: 5px 20px;
   border-radius: 20px;
+  max-height: 35px;
+`;
+
+export const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 20px;
 `;

--- a/types/StoreType.ts
+++ b/types/StoreType.ts
@@ -1,4 +1,5 @@
 import { LandingProps } from "../config/landingSlice";
+import { LeaderboardProps } from "../config/leaderboardSlice";
 import { MarketplaceProps } from "../config/marketplaceSlice";
 import { PortfolioProps } from "../config/portfolioSlice";
 import { TokenProps } from "../config/tokenSlice";
@@ -8,6 +9,7 @@ export type StoreType = {
   marketplace: MarketplaceProps;
   token: TokenProps;
   landing: LandingProps;
+  leaderboard: LeaderboardProps;
 };
 
 export default StoreType;


### PR DESCRIPTION
### Trello Card
- [start-the-implementation-of-the-artist-page](https://trello.com/c/ABFc59OP/50-start-the-implementation-of-the-artist-page)

### Description
- Minor UI improvement on the NFT details page.
- Implemented the algorithm to fetch the address of the NFT creator. The Moralis API doesn't offer this resource, so I had to improvise a bit: we get the list of the NFT owners, and then, by logic, the first owner is the creator. This is not a performatic solution, especially if the NFT has a huge list of owners, so I'll keep my eyes open for better solutions.
- The "See More" button, on the NFT details page, now takes the user to the artist's page.
- Implemented the loading and error states for the Leaderboard page, and placed the data in the global storage like everything else.
- Improved loading state of the NFT details page.
- Engineering and creative work on the Artist page. 