### PR TITLE
FEATURE - Navbar adjustments

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -37,6 +37,8 @@ import { switchTheme } from "../../config/themeSlice";
 function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isMarketplaceOpen, setIsMarketplaceOpen] = useState(false);
+  const [isMulletswapOpen, setIsMulletswapOpen] = useState(false);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -44,6 +46,8 @@ function Header() {
   const { pathname, push } = useRouter();
   const containerRef = useRef<HTMLElement>(null);
   const marketplaceDropdownRef = useRef<HTMLDivElement>(null);
+  const mulletswapDropdownRef = useRef<HTMLDivElement>(null);
+  const createDropdownRef = useRef<HTMLDivElement>(null);
   const userDropdownRef = useRef<HTMLDivElement>(null);
   const isLandingPage = pathname === "/";
   const { isDarkMode } = useSelector((store: StoreType) => store.theme);
@@ -116,7 +120,7 @@ function Header() {
             <DropdownArea position="left" isLandingPage={isLandingPage} isOpen={isMarketplaceOpen}>
               <DropdownItem onClick={() => redirectTo("/marketplace")}>Marketplace</DropdownItem>
               <DropdownItem onClick={() => redirectTo("/marketplace/minters")}>Minters Market</DropdownItem>
-              <DropdownItem onClick={() => redirectTo("/marketplace/mulletswap")}>MulletSwap</DropdownItem>
+              <DropdownItem onClick={() => redirectTo("/")}>Shared Storefronts</DropdownItem>
             </DropdownArea>
           </Dropdown>
         )}
@@ -132,16 +136,30 @@ function Header() {
             placeholder="Search items, collections, and accounts"
           />
         </Search>
-        <Tab onClick={() => redirectTo("/create")} isLandingPage={isLandingPage} isOpen={isMenuOpen}>
-          Create
-        </Tab>
-        <Tab
-          onClick={() => redirectTo(`/profile/${user?.get("ethAddress")}`)}
-          isLandingPage={isLandingPage}
-          isOpen={isMenuOpen}
-        >
-          Profile
-        </Tab>
+        <Dropdown isLandingPage={isLandingPage} isOpen={isMenuOpen} ref={createDropdownRef}>
+          <DropdownButton onClick={() => setIsCreateOpen(!isCreateOpen)}>
+            <Tab isLandingPage={isLandingPage} isOpen={isMenuOpen}>
+              <DropdownLabel isLandingPage={isLandingPage}>Create</DropdownLabel>
+              <FiChevronDown color={getFontColor()} />
+            </Tab>
+          </DropdownButton>
+          <DropdownArea position="left" isLandingPage={isLandingPage} isOpen={isCreateOpen}>
+            <DropdownItem onClick={() => redirectTo("/create")}>Lazy Minting</DropdownItem>
+            <DropdownItem onClick={() => redirectTo("/")}>Form a Guild</DropdownItem>
+          </DropdownArea>
+        </Dropdown>
+        <Dropdown isLandingPage={isLandingPage} isOpen={isMenuOpen} ref={mulletswapDropdownRef}>
+          <DropdownButton onClick={() => setIsMulletswapOpen(!isMulletswapOpen)}>
+            <Tab isLandingPage={isLandingPage} isOpen={isMenuOpen}>
+              <DropdownLabel isLandingPage={isLandingPage}>Mulletswap</DropdownLabel>
+              <FiChevronDown color={getFontColor()} />
+            </Tab>
+          </DropdownButton>
+          <DropdownArea position="left" isLandingPage={isLandingPage} isOpen={isMulletswapOpen}>
+            <DropdownItem onClick={() => redirectTo("/mulletswap", { src: "lifi" })}>Bridge and Swap</DropdownItem>
+            <DropdownItem onClick={() => redirectTo("/mulletswap", { src: "onramper" })}>Fiat On-Ramp</DropdownItem>
+          </DropdownArea>
+        </Dropdown>
         {!isAuthenticated && (
           <Tab onClick={openAuthModal} isLandingPage={isLandingPage} isOpen={isMenuOpen}>
             Sign In
@@ -152,9 +170,14 @@ function Header() {
             <DropdownButton onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}>
               <UserWrapper isOpen={isMenuOpen}>
                 {imageUrl ? (
-                  <ProfilePicture style={{ backgroundImage: `url(${imageUrl})` }} />
+                  <ProfilePicture
+                    style={{ backgroundImage: `url(${imageUrl})` }}
+                    onClick={() => redirectTo(`/profile/${user?.get("ethAddress")}`)}
+                  />
                 ) : (
-                  <Blockie seed={user?.get("ethAddress")} scale={3} />
+                  <span onClick={() => redirectTo(`/profile/${user?.get("ethAddress")}`)}>
+                    <Blockie seed={user?.get("ethAddress")} scale={3} />
+                  </span>
                 )}
                 <UserAddress isLandingPage={isLandingPage}>
                   {username || getDisplayName(user?.get("ethAddress"))}
@@ -163,6 +186,7 @@ function Header() {
               </UserWrapper>
             </DropdownButton>
             <DropdownArea position="right" isLandingPage={isLandingPage} isOpen={isUserMenuOpen}>
+              <DropdownItem onClick={() => redirectTo(`/profile/${user?.get("ethAddress")}`)}>Profile</DropdownItem>
               <DropdownItem onClick={() => redirectTo("/settings")}>Settings</DropdownItem>
               <DropdownItem onClick={() => redirectTo("/account")}>Account</DropdownItem>
               <DropdownItem>

--- a/components/Header/HeaderStyled.ts
+++ b/components/Header/HeaderStyled.ts
@@ -81,6 +81,9 @@ export const MenuIcon = styled(FiMenu)`
 
 export const Tab = styled.a<HeaderType>`
   padding: 20px 10px;
+  height: 30px;
+  display: flex;
+  align-items: center;
   color: ${(props) => (props.isLandingPage ? COLORS.CLEAR : props.theme?.TITLE)};
   cursor: pointer;
   &:hover {

--- a/pages/mulletswap.tsx
+++ b/pages/mulletswap.tsx
@@ -1,28 +1,21 @@
 import type { NextPage } from "next";
-import { useState } from "react";
-import { Select } from "web3uikit";
-import { Main, Container, SourceHeader } from "../../styles/MulletSwapStyled";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { Main, Container } from "../styles/MulletSwapStyled";
 
 type SourceType = "lifi" | "onramper";
 const Mulletswap: NextPage = () => {
+  const { query } = useRouter();
+  const urlSource: SourceType = (Array.isArray(query.src) ? query.src[0] : query.src || "") as SourceType;
   const [source, setSource] = useState<SourceType>("lifi");
-  const SOURCES = [
-    { id: "lifi", label: "LI:FI" },
-    { id: "onramper", label: "Onramper" },
-  ];
+
+  useEffect(() => {
+    setSource(urlSource);
+  }, [urlSource]);
 
   return (
     <Main style={{ backgroundColor: "#FFFFFF" }}>
       <Container>
-        <SourceHeader>
-          <Select
-            defaultOptionIndex={0}
-            onChange={({ id }) => setSource(id as SourceType)}
-            options={SOURCES}
-            prefixText="Chain:"
-            value={source}
-          />
-        </SourceHeader>
         {source === "lifi" && (
           <iframe
             height="100%"


### PR DESCRIPTION
### DWork Card
- [Nav Bar Adjustments](https://app.dework.xyz/mulletverse/mvp-4?step=discord&taskId=868c2b52-91b8-4287-8a52-39ca1123501b)

### Description
- Removed the "profile" tab from the navigation bar. The user will now access the page by clicking on the profile picture or the newly added "profile" menu item inside the dropdown.
- Removed the "MulletSwap" tab from the marketplace dropdown. It is now accessible through its own dropdown directly on the navigation bar. Since the user will now choose between LiFi or Onramper directly on the dropdown, I have removed the selector from inside the page.
- The "Create" tab is now a dropdown containing the items "Lazy Mint" and "Form a Guild". The first will take the user to the Create page, and the second to the landing page, since we don't have the "Form a Guild" page.
- Added the item "Shared Storefronts" on the Marketplace dropdown. It will take the user to the Landing page since we don't have this page yet.